### PR TITLE
Add empty dependencies array in AMD define

### DIFF
--- a/lib/observable.coffee
+++ b/lib/observable.coffee
@@ -54,7 +54,7 @@ class Observable
 
 
 if typeof define is 'function' and define.amd
-	define 'observable', -> Observable
+	define 'observable', [], -> Observable
 else if typeof exports isnt 'undefined'
 	module.exports = Observable
 else


### PR DESCRIPTION
Seems like `r.js` v 2.1.x have a bug when module don't define dependency.

I guess that should be fixed on `r.js`, I'll open an issue over there. But that's an easy fix to make the AMD work for now.
